### PR TITLE
Removed unnecessary CDs argument from query.

### DIFF
--- a/lib/P3DataAPI.pm
+++ b/lib/P3DataAPI.pm
@@ -954,7 +954,6 @@ sub retrieve_nucleotide_feature_sequence {
                         }
                         return 1;
                     },
-                    [ "eq",     "feature_type", "CDS" ],
                     [ "in",     "patric_id", "(" . join(",", map { uri_escape($_) } @$fids) . ")"],
                     [ "select", "patric_id,na_sequence_md5" ],
                    );


### PR DESCRIPTION
This should allow RNA sequences to be obtained as well as CD sequences.