### PR TITLE
Add input/output mode to CLI --help output

### DIFF
--- a/lib/P3Utils.pm
+++ b/lib/P3Utils.pm
@@ -1173,6 +1173,11 @@ the calling code may emit detailed usage messages if needed.
 sub script_opts {
     # Get the parameters.
     my ($parmComment, @options) = @_;
+    # Check for an input spec hash as the first option.
+    my $banner = "";
+    if (ref($options[0]) eq 'HASH' && $options[0]->{_input_spec}) {
+        $banner = shift(@options)->{_input_spec};
+    }
     # Insure we can talk to PATRIC from inside Argonne.
     $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0;
     # Parse the command line.
@@ -1180,10 +1185,48 @@ sub script_opts {
            [ "help|h", "display usage information", { shortcircuit => 1}]);
     # The above method dies if the options are invalid. We check here for the HELP option.
     if ($retVal->help) {
+        print $banner if $banner;
         print $usage->text;
         exit;
     }
     return wantarray ? ($retVal, $usage) : $retVal;
+}
+
+=head3 input_spec
+
+    my $spec = P3Utils::input_spec(input => "...", output => "...", example => "...");
+
+Returns a formatted banner string describing a script's input/output model, for
+display in the C<--help> output. Pass the result as C<< { _input_spec => $spec } >>
+as the first element of the options list to L</script_opts>.
+
+=over 4
+
+=item input
+
+Description of what the script reads (e.g., "tab-delimited genome IDs on stdin").
+
+=item output
+
+Description of what the script produces.
+
+=item example
+
+A one-line usage example showing a typical invocation or pipeline.
+
+=back
+
+=cut
+
+sub input_spec {
+    my (%args) = @_;
+    my @lines;
+    push @lines, "" ;
+    push @lines, "  Input:   $args{input}" if $args{input};
+    push @lines, "  Output:  $args{output}" if $args{output};
+    push @lines, "  Example: $args{example}" if $args{example};
+    push @lines, "";
+    return join("\n", @lines) . "\n";
 }
 
 =head3 print_cols


### PR DESCRIPTION
## Summary
- Adds `P3Utils::input_spec()` function that generates a formatted Input/Output/Example banner
- Modifies `script_opts()` to accept an optional `{ _input_spec => ... }` hash that prints before the options list in `--help`
- Backward compatible — scripts without `_input_spec` are unaffected

This is the library support for the corresponding p3_cli PR that adds input specs to 95 CLI scripts.

## Example output

```
  Input:   tab-delimited genome IDs on stdin (or --input file)
  Output:  tab-delimited feature data
  Example: p3-all-genomes --eq genus,Methylobacillus | p3-get-genome-features --attr product

p3-get-genome-features.pl [-abcefhiKr] [long options...]
  --attr STR... (or -a)   field(s) to return
  ...
```

## Test plan
- [x] `p3-all-genomes --help` shows Input/Output/Example banner
- [x] `p3-get-genome-features --help` shows stdin pipeline description
- [x] `p3-gto --help` shows dual-mode (args or - for stdin)
- [x] Scripts without input_spec still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)