### PR TITLE
Route p3_core LWP clients through P3ClientUA; diagnose Cloudflare blocks

### DIFF
--- a/lib/P3DataAPI.pm
+++ b/lib/P3DataAPI.pm
@@ -23,6 +23,7 @@ eval {
 
 use HTTP::Request::Common;
 use Data::Dumper;
+use P3ClientUA;
 
 our $have_workspace;
 eval {
@@ -151,11 +152,9 @@ sub new {
     $url ||= $default_url;
 
     # The data API sits behind Cloudflare, which bans the default libwww-perl
-    # user-agent (error 1010). Present a configurable, allowlisted UA instead.
-    my $ua = LWP::UserAgent->new();
-    $ua->agent($FIG_Config::p3_data_api_user_agent
-               || $ENV{P3_USER_AGENT}
-               || "BV-BRC P3 Client");
+    # user-agent (error 1010). P3ClientUA presents an allowlisted one; it is
+    # the single definition of that string for every client in the tree.
+    my $ua = P3ClientUA::new_ua();
 
     my $self = {
         url        => $url,
@@ -500,7 +499,16 @@ sub submit_query {
             }
         } else {
             my $content = $response->content || "";
-            $error = "Failed: " . $response->code . " $content\nquery = $url?$q";
+            #
+            # A Cloudflare rejection is not our service answering; say so, and
+            # dump the exchange when P3_DEBUG_HTTP is set.
+            #
+            P3ClientUA::dump_http_failure($response, \*STDERR) if P3ClientUA::debug_enabled();
+            if (P3ClientUA::is_cloudflare_block($response)) {
+                $error = P3ClientUA::http_failure_message($response, "Query") . "\nquery = $url?$q";
+            } else {
+                $error = "Failed: " . $response->code . " $content\nquery = $url?$q";
+            }
         }
         if ($error) {
             if ($tries >= 15) {
@@ -717,6 +725,8 @@ sub solr_query_raw
     }
     else
     {
+        P3ClientUA::dump_http_failure($res, \*STDERR) if P3ClientUA::debug_enabled();
+        die P3ClientUA::http_failure_message($res, "Query") if P3ClientUA::is_cloudflare_block($res);
         die "Query failed: " . $res->code . " " . $res->content;
     }
 }
@@ -755,6 +765,8 @@ sub solr_query_raw_list
     }
     else
     {
+        P3ClientUA::dump_http_failure($res, \*STDERR) if P3ClientUA::debug_enabled();
+        die P3ClientUA::http_failure_message($res, "Query") if P3ClientUA::is_cloudflare_block($res);
         die "Query failed: " . $res->code . " " . $res->content;
     }
 }

--- a/lib/P3UserAPI.pm
+++ b/lib/P3UserAPI.pm
@@ -14,6 +14,7 @@ use Digest::MD5 'md5_hex';
 use Time::HiRes 'gettimeofday';
 use HTTP::Request::Common;
 use Data::Dumper;
+use P3ClientUA;
 
 our $have_p3auth;
 eval {
@@ -86,7 +87,7 @@ sub new {
     my $self = {
         url        => $url,
         chunk_size => 25000,
-        ua         => LWP::UserAgent->new(),
+        ua         => P3ClientUA::new_ua(),
         token      => $token,
         benchmark  => 0,
         raw        => 0,

--- a/lib/P3Utils.pm
+++ b/lib/P3Utils.pm
@@ -29,6 +29,7 @@ package P3Utils;
     use Digest::MD5;
     use RoleParse;
     use P3View;
+    use P3ClientUA;
 
 =head1 PATRIC Script Utilities
 
@@ -1695,7 +1696,7 @@ sub list_object_fields {
     # Get the real name of the object.
     my $realName = OBJECTS->{$object};
     # Ask for the JSON schema string.
-    my $ua = LWP::UserAgent->new();
+    my $ua = P3ClientUA::new_ua();
     my $url = $p3->{url} . "/$realName/schema?http_content-type=application/solrquery+x-www-form-urlencoded&http_accept=application/solr+json";
     my $request = HTTP::Request->new(GET => $url);
     my $response = $ua->request($request);


### PR DESCRIPTION
## Why

The BV-BRC sites sit behind Cloudflare, which rejects disallowed library user-agents with **error 1010** before the request reaches the origin. `P3UserAPI` and `P3Utils` built a bare `LWP::UserAgent`, so they announced themselves as `libwww-perl` — exactly the string that rule bans. And when a request *was* rejected, the error said nothing that would distinguish an edge rejection from a service failure.

Depends on **BV-BRC/p3_auth#6**, which adds `P3ClientUA`. Companion PR for `p3_cli` (BV-BRC/p3_cli#22); the Go SDK gets an equivalent `internal/httpdiag`.

## What

All three LWP clients now build their agent with `P3ClientUA::new_ua()`, which preserves the precedence established by #21 (`$FIG_Config::p3_data_api_user_agent` → `$ENV{P3_USER_AGENT}` → `"BV-BRC P3 Client"`). `P3DataAPI` keeps its behaviour but stops being the only place that knows the agent string — this generalises #21 to the other two clients, and to the other two modules.

`P3DataAPI`'s three failure paths now say when the *edge*, not the service, rejected us: the `submit_query` retry loop and both `solr_query_raw` dies.

## Verified live

This is where a block actually reproduces. Forcing a `libwww-perl` agent against `www.patricbrc.org/api`:

```
Query failed: 403 Forbidden - blocked by Cloudflare (error 1010: user-agent not allowed).
The user agent presented was 'libwww-perl/6.67'. [CF-Ray a2cb0e6ac8d41e79-ORD]
Re-run with P3_DEBUG_HTTP=1 for the full HTTP headers.
```

Before, that same failure produced only `Query failed: 403 error code: 1010`.

That live reproduction is also what showed the rejection arrives in **three** different shapes — HTML, JSON, and a terse `text/plain`. The solr path gets the `text/plain` one, whose colon (`error code: 1010`) is why the matcher in `P3ClientUA` is as loose as it is.

With `P3_DEBUG_HTTP=1` the full exchange is dumped, with `Authorization: <redacted, 470 bytes>` and `Set-Cookie: <redacted, 309 bytes>`.

## Two things I did not do

- **The retry wart.** `submit_query` retries a 1010 **fifteen times over ~135 s**, even though Cloudflare marks it `"retryable":false`. Out of scope here, but worth fixing. `solr_query_raw` dies immediately and is the fast way to reproduce a block.
- **Testing.** There are no unit tests in this PR; the detection logic and its redaction guarantees are tested in `p3_auth` (27 offline TAP tests), and this side was verified against production as above.

A normal query is byte-identical to before when `P3_DEBUG_HTTP` is unset — the only default-on changes are the richer text of an *already failing* error, and the user-agent on the two clients that were sending `libwww-perl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
