### PR TITLE
Add retrieve_private_genome_metadata to P3DataAPI

### DIFF
--- a/lib/P3DataAPI.pm
+++ b/lib/P3DataAPI.pm
@@ -643,7 +643,7 @@ sub query_cb {
     {
         my $lim = "limit($chunk,$start)";
         my $q   = "$qstr&$lim";
-	print STDERR "$self->{url} $core $q\n";
+	# print STDERR "$self->{url} $core $q\n";
         my ($resp, $data) = $self->submit_query($core, $q);
 
         my $r = $resp->header('content-range');
@@ -1663,6 +1663,32 @@ sub retrieve_genome_metadata {
 
     $self->query_cb(
         "genome",
+        sub {
+            my ($data) = @_;
+            push( @out, @$data );
+            return 1;
+        },
+        $qry,
+        [ "select", @$keys ]
+    );
+    return @out;
+}
+
+sub retrieve_private_genome_metadata {
+    my ( $self, $genomes, $keys ) = @_;
+
+    my @out;
+
+    my $qry;
+    if ( ref($genomes) ) {
+        my $q = join( ",", @$genomes );
+        $qry = [ "in", "genome_id", "($q)" ];
+    } else {
+        $qry = [ "eq", "genome_id", $genomes ];
+    }
+
+    $self->query_cb(
+        "private_genome_metadata",
         sub {
             my ($data) = @_;
             push( @out, @$data );


### PR DESCRIPTION
Adds `P3DataAPI::retrieve_private_genome_metadata`, mirroring the existing
`retrieve_genome_metadata` but querying the `private_genome_metadata` core.
Accepts either a single genome id or an arrayref of ids, plus the list of
fields to select, and returns the collected rows.

Also comments out a stray debug `print STDERR` in `query_cb` that was
introduced by the User-Agent work in #22 and is currently firing on every
paged query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)